### PR TITLE
Add database integration with PostgreSQL and ActiveRecord

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,20 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: localhost
+  port: 5432
+  database: product_miner
+  username: postgres
+  password: your_password
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+  database: product_miner_test
+
+production:
+  <<: *default
+  database: product_miner_production

--- a/db/migrate/20260603000000_create_products_and_prices.rb
+++ b/db/migrate/20260603000000_create_products_and_prices.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "../db"
+
+ActiveRecord::Schema.define do
+  create_table :products, force: true do |t|
+    t.string :external_id, null: false
+    t.string :name
+    t.string :store, null: false
+    t.timestamps
+  end
+
+  create_table :prices, force: true do |t|
+    t.references :product, null: false, foreign_key: true
+    t.decimal :price, precision: 10, scale: 2
+    t.datetime :recorded_at, null: false
+    t.jsonb :metadata
+  end
+end

--- a/lib/product_miner/db.rb
+++ b/lib/product_miner/db.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "active_record"
+require "yaml"
+
+module ProductMiner
+  class DB
+    def self.connect!
+      config = YAML.load_file("config/database.yml")[ENV.fetch("ENV", "development")]
+      ActiveRecord::Base.establish_connection(config)
+    end
+  end
+end

--- a/lib/product_miner/models/price.rb
+++ b/lib/product_miner/models/price.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "product"
+
+module ProductMiner
+  class Price < ActiveRecord::Base
+    belongs_to :product
+    
+    validates :price, presence: true, numericality: { greater_than: 0 }
+    validates :recorded_at, presence: true
+  end
+end

--- a/lib/product_miner/models/product.rb
+++ b/lib/product_miner/models/product.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "db"
+
+module ProductMiner
+  class Product < ActiveRecord::Base
+    has_many :prices, dependent: :destroy
+    
+    validates :external_id, presence: true, uniqueness: { scope: :store }
+    validates :store, presence: true
+  end
+end

--- a/spec/foreman/foreman_spec.rb
+++ b/spec/foreman/foreman_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ProductMiner::Foreman do
+  let(:foreman) { described_class.new }
+
+  describe "#perform" do
+    let(:product_id) { "204451300000" }
+    let(:mock_data) do
+      {
+        "price" => { "value" => 15.99 },
+        "name" => "Test Product"
+      }
+    end
+
+    before do
+      # Mock MigrosApi
+      allow(ProductMiner::MigrosApi).to receive(:new).and_return(
+        double(read_product_details: mock_data)
+      )
+    end
+
+    it "creates a product and price record" do
+      expect { foreman.perform("migros", product_id) }
+        .to change { ProductMiner::Product.count }.by(1)
+        .and change { ProductMiner::Price.count }.by(1)
+
+      product = ProductMiner::Product.last
+      expect(product.external_id).to eq(product_id)
+      expect(product.store).to eq("migros")
+
+      price = ProductMiner::Price.last
+      expect(price.price).to eq(15.99)
+      expect(price.product).to eq(product)
+    end
+
+    it "does not create duplicate products" do
+      ProductMiner::Product.create!(external_id: product_id, store: "migros")
+      
+      expect { foreman.perform("migros", product_id) }
+        .to change { ProductMiner::Product.count }.by(0)
+        .and change { ProductMiner::Price.count }.by(1)
+    end
+  end
+end

--- a/spec/miners/migros_api_spec.rb
+++ b/spec/miners/migros_api_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ProductMiner::MigrosApi do
+  let(:api) { described_class.new }
+
+  describe "#authorize" do
+    before do
+      stub_request(:get, "https://www.migros.ch/authentication/public/v1/api/guest?authorizationNotRequired=true")
+        .to_return(
+          status: 200,
+          headers: { leshopch: "test_header" },
+          body: "{}"
+        )
+    end
+
+    it "sets auth_state to :AUTHORIZED when leshopch header is present" do
+      expect { api.authorize }
+        .to change { api.instance_variable_get(:@auth_state) }
+        .from(:UNAUTHORIZED).to(:AUTHORIZED)
+    end
+
+    it "sets leshopch_header" do
+      api.authorize
+      expect(api.instance_variable_get(:@leshopch_header)).to eq("test_header")
+    end
+  end
+
+  describe "#read_product_details" do
+    let(:product_id) { "204451300000" }
+    let(:mock_response) do
+      {
+        "price" => { "value" => 10.95 },
+        "name" => "Test Product"
+      }
+    end
+
+    before do
+      stub_request(:get, "https://www.migros.ch/authentication/public/v1/api/guest?authorizationNotRequired=true")
+        .to_return(
+          status: 200,
+          headers: { leshopch: "test_header" },
+          body: "{}"
+        )
+
+      stub_request(:get, "https://www.migros.ch/product-display/public/v2/product-detail")
+        .with(query: { storeType: "OFFLINE", warehouseId: 2, region: "national", migrosIds: product_id })
+        .to_return(
+          status: 200,
+          headers: {},
+          body: mock_response.to_json
+        )
+    end
+
+    it "returns parsed product details" do
+      result = api.read_product_details(product_id)
+      expect(result["price"]["value"]).to eq(10.95)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

This PR adds database integration to ProductMiner, enabling the storage of product prices and metadata.

### New Features
- PostgreSQL Integration: Added pg and activerecord gems for database support
- Database Models: Product and Price models to store product information and price history
- Database Configuration: config/database.yml for environment-specific settings
- Migration: Initial schema for products and prices tables
- Enhanced Foreman: Now saves fetched prices to the database
- Improved Error Handling: Added retries with exponential backoff for API calls
- RSpec Tests: Added comprehensive tests for MigrosApi and Foreman

### Files Changed
- Added: config/database.yml, lib/product_miner/db.rb, lib/product_miner/models/product.rb, lib/product_miner/models/price.rb, db/migrate/20260603000000_create_products_and_prices.rb, spec/spec_helper.rb, spec/miners/migros_api_spec.rb, spec/foreman/foreman_spec.rb
- Modified: Gemfile, lib/product_miner/foreman/foreman.rb, lib/product_miner/miners/migros_api.rb, lib/product_miner.rb, Rakefile, .gitignore

### How to Use
1. Setup PostgreSQL:
   docker run --name pm-postgres -e POSTGRES_PASSWORD=your_password -p 5432:5432 -d postgres

2. Create databases:
   createdb product_miner
   createdb product_miner_test

3. Run migrations:
   rake db:setup

4. Install jobs:
   rake jobs:install

5. Run tests:
   rspec

### Next Steps
- Add configuration file for multiple products
- Implement product management CLI
- Add more miners (e.g., Coop, Digitec)
- Create web interface (Rails)

Closes #1 (First Miner - reduced features)